### PR TITLE
fix: clean up click outside listener

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -15,7 +15,13 @@ import { RiMenu5Fill } from 'react-icons/ri';
 
 import resumePDF from '../assets/Ganga_Resume.pdf';
 
+// Store listeners and a shared dispatcher so the same reference is used for
+// adding and removing the global event handler. Previously an anonymous
+// function was passed to both `addEventListener` and `removeEventListener`,
+// which meant the cleanup never removed the original listener.
 const listeners = new Set();
+const dispatchMouseDown = (evt) => listeners.forEach((l) => l(evt));
+
 function useClickOutside(ref, onOutsideClick, excludeRef) {
   const handler = useCallback(
     (e) => {
@@ -29,15 +35,11 @@ function useClickOutside(ref, onOutsideClick, excludeRef) {
   useEffect(() => {
     listeners.add(handler);
     if (listeners.size === 1)
-      document.addEventListener('mousedown', (evt) =>
-        listeners.forEach((l) => l(evt))
-      );
+      document.addEventListener('mousedown', dispatchMouseDown);
     return () => {
       listeners.delete(handler);
       if (listeners.size === 0)
-        document.removeEventListener('mousedown', (evt) =>
-          listeners.forEach((l) => l(evt))
-        );
+        document.removeEventListener('mousedown', dispatchMouseDown);
     };
   }, [handler]);
 }


### PR DESCRIPTION
## Summary
- ensure Navbar's click outside hook removes its event listener by using a shared dispatcher

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68785ce9bbd8832c9365072e94413bcd